### PR TITLE
feat: Router 컴포넌트 구현 및 라우팅 구현 (MAT-86)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,13 @@
 import React from 'react';
+import { BrowserRouter } from 'react-router-dom';
+import Router from './Router/Router';
 
-const App = () => <div>Hello World!</div>;
+const App = () => {
+  return (
+    <BrowserRouter>
+      <Router />
+    </BrowserRouter>
+  );
+};
 
 export default App;

--- a/src/Router/AuthorizedRoute.tsx
+++ b/src/Router/AuthorizedRoute.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 // eslint-disable-next-line import/no-extraneous-dependencies
-import { Redirect, Route, RouteProps } from 'react-router';
+import { Redirect, Route, RouteProps } from 'react-router-dom';
 import { getItemFromStorage } from '@/utils/storage';
 
 export interface AuthorizedRouterProps extends RouteProps {
@@ -8,13 +8,17 @@ export interface AuthorizedRouterProps extends RouteProps {
 }
 
 // eslint-disable-next-line @typescript-eslint/no-shadow
-const AuthorizedRouter: React.FC<AuthorizedRouterProps> = (props) => {
+const AuthorizedRouter = ({
+  path,
+  component,
+  redirectPath = '/login',
+  exact,
+}: AuthorizedRouterProps) => {
   const token = getItemFromStorage('token') || null;
-  const { component, redirectPath } = props;
 
   return token ? (
     // eslint-disable-next-line react/jsx-props-no-spreading
-    <Route {...props} component={component} />
+    <Route exact={exact} component={component} path={path} />
   ) : (
     <Redirect to={{ pathname: redirectPath }} />
   );

--- a/src/Router/AuthorizedRoute.tsx
+++ b/src/Router/AuthorizedRoute.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { Redirect, Route, RouteProps } from 'react-router';
+import { getItemFromStorage } from '@/utils/storage';
+
+export interface AuthorizedRouterProps extends RouteProps {
+  redirectPath: string;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-shadow
+const AuthorizedRouter: React.FC<AuthorizedRouterProps> = (props) => {
+  const token = getItemFromStorage('token') || null;
+  const { component, redirectPath } = props;
+
+  return token ? (
+    // eslint-disable-next-line react/jsx-props-no-spreading
+    <Route {...props} component={component} />
+  ) : (
+    <Redirect to={{ pathname: redirectPath }} />
+  );
+};
+
+export default AuthorizedRouter;

--- a/src/Router/Router.tsx
+++ b/src/Router/Router.tsx
@@ -1,18 +1,19 @@
 import React from 'react';
 import { Route, Switch } from 'react-router-dom';
 
+// TODO: Router관련 const 객체로 변경해 보기
 import {
   HOME_PAGE,
-  MERCENARY_PAGE,
-  MERCENARY_DETAIL_PAGE,
-  MERCENARY_POST_PAGE,
-  MERCENARY_EDIT_PAGE,
-  MERCENARY_CHAT_PAGE,
-  MERCENARY_ACCEPT_PAGE,
-  MATCHING_PAGE,
-  MATCHING_POST_PAGE,
-  MATCHING_DETAIL_PAGE,
-  MATCHING_EDIT_PAGE,
+  HIRES_PAGE,
+  HIRES_DETAIL_PAGE,
+  HIRES_POST_PAGE,
+  HIRES_EDIT_PAGE,
+  HIRES_CHAT_PAGE,
+  HIRES_ACCEPT_PAGE,
+  MATCHES_PAGE,
+  MATCHES_POST_PAGE,
+  MATCHES_DETAIL_PAGE,
+  MATCHES_EDIT_PAGE,
   TEAM_PAGE,
   TEAM_CREATE_PAGE,
   TEAM_MATCHING_LIST_PAGE,
@@ -22,6 +23,7 @@ import {
   TEAM_MEMBERS_EDIT_PAGE,
   SIGNUP_PAGE,
   LOGIN_PAGE,
+  SETTING_PAGE,
   USER_PAGE,
   USER_EDIT_PAGE,
   USER_MATCHING_LIST_PAGE,
@@ -37,16 +39,16 @@ const Router: React.FC = () => {
       {/* <AuthorizedRouter path={MERCENARY_PAGE} exact component={} redirectPath="" />
       <Route path={HOME_PAGE} exact component={} />
       <Route path={HOME_PAGE} exact component={} />
-      <Route path={MERCENARY_PAGE} exact component={} />
-      <Route path={MERCENARY_DETAIL_PAGE} exact component={} />
-      <Route path={MERCENARY_POST_PAGE} exact component={} />
-      <Route path={MERCENARY_EDIT_PAGE} exact component={} />
-      <Route path={MERCENARY_CHAT_PAGE} exact component={} />
-      <Route path={MERCENARY_ACCEPT_PAGE} exact component={} />
-      <Route path={MATCHING_PAGE} exact component={} />
-      <Route path={MATCHING_POST_PAGE} exact component={} />
-      <Route path={MATCHING_DETAIL_PAGE} exact component={} />
-      <Route path={MATCHING_EDIT_PAGE} exact component={} />
+      <Route path={HIRES_PAGE} exact component={} />
+      <Route path={HIRES_DETAIL_PAGE} exact component={} />
+      <Route path={HIRES_POST_PAGE} exact component={} />
+      <Route path={HIRES_EDIT_PAGE} exact component={} />
+      <Route path={HIRES_CHAT_PAGE} exact component={} />
+      <Route path={HIRES_ACCEPT_PAGE} exact component={} />
+      <Route path={MATCHES_PAGE} exact component={} />
+      <Route path={MATCHES_POST_PAGE} exact component={} />
+      <Route path={MATCHES_DETAIL_PAGE} exact component={} />
+      <Route path={MATCHES_EDIT_PAGE} exact component={} />
       <Route path={TEAM_PAGE} exact component={} />
       <Route path={TEAM_CREATE_PAGE} exact component={} />
       <Route path={TEAM_MATCHING_LIST_PAGE} exact component={} />
@@ -56,6 +58,7 @@ const Router: React.FC = () => {
       <Route path={TEAM_MEMBERS_EDIT_PAGE} exact component={} />
       <Route path={SIGNUP_PAGE} exact component={} />
       <Route path={LOGIN_PAGE} exact component={} />
+      <Route path={SETTING_PAGE} exact component={} />
       <Route path={USER_PAGE} exact component={} />
       <Route path={USER_EDIT_PAGE} exact component={} />
       <Route path={USER_MATCHING_LIST_PAGE} exact component={} />

--- a/src/Router/Router.tsx
+++ b/src/Router/Router.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import { Route, Switch } from 'react-router-dom';
+
+import {
+  HOME_PAGE,
+  MERCENARY_PAGE,
+  MERCENARY_DETAIL_PAGE,
+  MERCENARY_POST_PAGE,
+  MERCENARY_EDIT_PAGE,
+  MERCENARY_CHAT_PAGE,
+  MERCENARY_ACCEPT_PAGE,
+  MATCHING_PAGE,
+  MATCHING_POST_PAGE,
+  MATCHING_DETAIL_PAGE,
+  MATCHING_EDIT_PAGE,
+  TEAM_PAGE,
+  TEAM_CREATE_PAGE,
+  TEAM_MATCHING_LIST_PAGE,
+  TEAM_EDIT_PAGE,
+  TEAM_SELECT_PAGE,
+  TEAM_MEMBERS_PAGE,
+  TEAM_MEMBERS_EDIT_PAGE,
+  SIGNUP_PAGE,
+  LOGIN_PAGE,
+  USER_PAGE,
+  USER_EDIT_PAGE,
+  USER_MATCHING_LIST_PAGE,
+  USER_TEAM_INVITAION_LIST_PAGE,
+  USER_MERCENARY_INVITAION_LIST_PAGE,
+  NOT_FOUND_PAGE,
+} from '../consts/routes';
+import AuthorizedRouter from './AuthorizedRoute';
+
+const Router: React.FC = () => {
+  return (
+    <Switch>
+      {/* <AuthorizedRouter path={MERCENARY_PAGE} exact component={} redirectPath="" />
+      <Route path={HOME_PAGE} exact component={} />
+      <Route path={HOME_PAGE} exact component={} />
+      <Route path={MERCENARY_PAGE} exact component={} />
+      <Route path={MERCENARY_DETAIL_PAGE} exact component={} />
+      <Route path={MERCENARY_POST_PAGE} exact component={} />
+      <Route path={MERCENARY_EDIT_PAGE} exact component={} />
+      <Route path={MERCENARY_CHAT_PAGE} exact component={} />
+      <Route path={MERCENARY_ACCEPT_PAGE} exact component={} />
+      <Route path={MATCHING_PAGE} exact component={} />
+      <Route path={MATCHING_POST_PAGE} exact component={} />
+      <Route path={MATCHING_DETAIL_PAGE} exact component={} />
+      <Route path={MATCHING_EDIT_PAGE} exact component={} />
+      <Route path={TEAM_PAGE} exact component={} />
+      <Route path={TEAM_CREATE_PAGE} exact component={} />
+      <Route path={TEAM_MATCHING_LIST_PAGE} exact component={} />
+      <Route path={TEAM_EDIT_PAGE} exact component={} />
+      <Route path={TEAM_SELECT_PAGE} exact component={} />
+      <Route path={TEAM_MEMBERS_PAGE} exact component={} />
+      <Route path={TEAM_MEMBERS_EDIT_PAGE} exact component={} />
+      <Route path={SIGNUP_PAGE} exact component={} />
+      <Route path={LOGIN_PAGE} exact component={} />
+      <Route path={USER_PAGE} exact component={} />
+      <Route path={USER_EDIT_PAGE} exact component={} />
+      <Route path={USER_MATCHING_LIST_PAGE} exact component={} />
+      <Route path={USER_TEAM_INVITAION_LIST_PAGE} exact component={} />
+      <Route path={USER_MERCENARY_INVITAION_LIST_PAGE} exact component={} />
+      <Route path={NOT_FOUND_PAGE} exact component={} /> */}
+    </Switch>
+  );
+};
+
+export default Router;

--- a/src/consts/routes.js
+++ b/src/consts/routes.js
@@ -2,18 +2,18 @@
 export const HOME_PAGE = '/';
 
 // 용병
-export const MERCENARY_PAGE = '/mercenary';
-export const MERCENARY_DETAIL_PAGE = '/mercenary/:postId';
-export const MERCENARY_POST_PAGE = '/mercenary/post/new';
-export const MERCENARY_EDIT_PAGE = '/mercenary/edit/:postId';
-export const MERCENARY_CHAT_PAGE = '/mercenary/chat/:postId';
-export const MERCENARY_ACCEPT_PAGE = '/mercenary/accept/:postId';
+export const HIRES_PAGE = '/hires';
+export const HIRES_DETAIL_PAGE = '/hires/:postId';
+export const HIRES_POST_PAGE = '/hires/post/new';
+export const HIRES_EDIT_PAGE = '/hires/edit/:postId';
+export const HIRES_CHAT_PAGE = '/hires/chat/:postId';
+export const HIRES_ACCEPT_PAGE = '/hires/accept/:postId';
 
 // 매칭
-export const MATCHING_PAGE = '/matching/';
-export const MATCHING_POST_PAGE = '/matching/post/new';
-export const MATCHING_DETAIL_PAGE = '/matching/post/:postId';
-export const MATCHING_EDIT_PAGE = '/matching/edit/:postId';
+export const MATCHES_PAGE = '/matches/';
+export const MATCHES_POST_PAGE = '/matches/post/new';
+export const MATCHES_DETAIL_PAGE = '/matches/post/:postId';
+export const MATCHES_EDIT_PAGE = '/matches/edit/:postId';
 
 // 팀
 export const TEAM_PAGE = '/team/:teamId';
@@ -27,6 +27,7 @@ export const TEAM_MEMBERS_EDIT_PAGE = '/team/:teamId/member/edit';
 // 회원
 export const SIGNUP_PAGE = '/signup';
 export const LOGIN_PAGE = '/login';
+export const SETTING_PAGE = '/setting';
 
 // 개인
 export const USER_PAGE = '/user';

--- a/src/consts/routes.js
+++ b/src/consts/routes.js
@@ -1,0 +1,39 @@
+// 메인
+export const HOME_PAGE = '/';
+
+// 용병
+export const MERCENARY_PAGE = '/mercenary';
+export const MERCENARY_DETAIL_PAGE = '/mercenary/:postId';
+export const MERCENARY_POST_PAGE = '/mercenary/post/new';
+export const MERCENARY_EDIT_PAGE = '/mercenary/edit/:postId';
+export const MERCENARY_CHAT_PAGE = '/mercenary/chat/:postId';
+export const MERCENARY_ACCEPT_PAGE = '/mercenary/accept/:postId';
+
+// 매칭
+export const MATCHING_PAGE = '/matching/';
+export const MATCHING_POST_PAGE = '/matching/post/new';
+export const MATCHING_DETAIL_PAGE = '/matching/post/:postId';
+export const MATCHING_EDIT_PAGE = '/matching/edit/:postId';
+
+// 팀
+export const TEAM_PAGE = '/team/:teamId';
+export const TEAM_CREATE_PAGE = '/team/new';
+export const TEAM_MATCHING_LIST_PAGE = '/team/:teamId/match';
+export const TEAM_EDIT_PAGE = '/team/:teamId/edit';
+export const TEAM_SELECT_PAGE = '/team/select';
+export const TEAM_MEMBERS_PAGE = '/team/:teamId/member';
+export const TEAM_MEMBERS_EDIT_PAGE = '/team/:teamId/member/edit';
+
+// 회원
+export const SIGNUP_PAGE = '/signup';
+export const LOGIN_PAGE = '/login';
+
+// 개인
+export const USER_PAGE = '/user';
+export const USER_EDIT_PAGE = '/user/edit';
+export const USER_MATCHING_LIST_PAGE = '/user/match';
+export const USER_TEAM_INVITAION_LIST_PAGE = '/user/team/invitation';
+export const USER_MERCENARY_INVITAION_LIST_PAGE = '/user/mercenary/invitaion';
+
+// 예외처리
+export const NOT_FOUND_PAGE = '/not-found';


### PR DESCRIPTION
## 추가한 기능
react-router v5를 통해 라우팅 기능 구현했습니다.
인증되지 않은 사용자는 redirect 시키도록 AuthorizedRoute 컴포넌트를 통해 구현했습니다.
라우팅 관련 상수를 구현해 path에 상수 사용했습니다.

라우팅시 렌더링될 컴포넌트 부분은 비워놓고 전부 주석처리해주었습니다. 
필요할 때 렌더링될 컴포넌트 넣어서 사용하시면 될 것 같습니다.

## 체크리스트
- [x] 라우팅 구현
- [x] Router 컴포넌트 구현
- [x] 라우팅 관련 상수 구현