### PR TITLE
feat: 팀 하위 페이지에 API 연결(MAT-163)

### DIFF
--- a/src/api/core.ts
+++ b/src/api/core.ts
@@ -20,7 +20,7 @@ const createApiMethod =
   (config: AxiosRequestConfig): Promise<any> => {
     _axiosInstance.interceptors.response.use((response) => {
       if (!response.data) return response;
-      return response.data;
+      return response.data.data;
     });
 
     return _axiosInstance({

--- a/src/api/core.ts
+++ b/src/api/core.ts
@@ -2,7 +2,7 @@ import axios, { AxiosInstance, AxiosRequestConfig, Method } from 'axios';
 import { HTTP_METHODS } from '@/consts';
 
 const axiosInstance: AxiosInstance = axios.create({
-  baseURL: 'https://api.helltabus.com',
+  baseURL: 'http://ec2-3-34-109-111.ap-northeast-2.compute.amazonaws.com',
   timeout: 5000,
 });
 
@@ -11,7 +11,7 @@ if (process.env.NODE_ENV === 'production') {
 }
 
 if (process.env.NODE_ENV === 'development') {
-  axiosInstance.defaults.headers.common.Authorization = process.env.DUMMY_TOKEN ?? '';
+  axiosInstance.defaults.headers.common.token = process.env.DUMMY_TOKEN ?? '';
 }
 
 const createApiMethod =

--- a/src/api/team.ts
+++ b/src/api/team.ts
@@ -10,6 +10,13 @@ interface TeamInfoProps {
   teamAgeGroup: string;
 }
 
+interface EditTeamInfoProps {
+  image: Record<string, string>;
+  teamBio: string;
+  teamAgeGroup: string;
+  teamId: number;
+}
+
 export const createTeam = ({
   image,
   teamName,
@@ -17,17 +24,17 @@ export const createTeam = ({
   teamSport,
   teamAgeGroup,
 }: TeamInfoProps) => {
-  const postFormImage = new FormData();
-  postFormImage.append('logo', image.file);
-  postFormImage.append('teamName', teamName);
-  postFormImage.append('bio', teamBio);
-  postFormImage.append('sports', teamSport);
-  postFormImage.append('ageGroup', teamAgeGroup);
+  const postFormData = new FormData();
+  postFormData.append('logo', image.file);
+  postFormData.append('teamName', teamName);
+  postFormData.append('bio', teamBio);
+  postFormData.append('sports', teamSport);
+  postFormData.append('ageGroup', teamAgeGroup);
 
   return api
     .post({
       url: '/teams',
-      data: postFormImage,
+      data: postFormData,
     })
     .catch(throwErrorMessage);
 };
@@ -53,6 +60,18 @@ export const withdrawTeam = (teamId: number) =>
       url: `/teams/${teamId}/me`,
     })
     .catch(throwErrorMessage);
+
+export const editTeamInfo = ({ image, teamBio, teamAgeGroup, teamId }: EditTeamInfoProps) => {
+  const postFormData = new FormData();
+  postFormData.append('logo', image.file);
+  postFormData.append('bio', teamBio);
+  postFormData.append('ageGroup', teamAgeGroup);
+
+  return api.put({
+    url: `/teams/${teamId}`,
+    data: postFormData,
+  });
+};
 
 export const deleteTeamMembers = (teamId: number, memberInfo: MemberElement[]) =>
   api

--- a/src/api/team.ts
+++ b/src/api/team.ts
@@ -1,11 +1,6 @@
 import { throwErrorMessage } from '@/utils/api';
 import api from '@/api/core';
-
-type MemberElementType = {
-  userId: number;
-  userName: string;
-  grade: string;
-};
+import { MemberElement } from '@/types';
 
 interface TeamInfoProps {
   image: Record<string, string>;
@@ -37,14 +32,13 @@ export const createTeam = ({
     .catch(throwErrorMessage);
 };
 
-export const checkTeamNameDuplication = (teamName: string) => {
-  return api
+export const checkTeamNameDuplication = (teamName: string) =>
+  api
     .get({
       url: `/teams/name-check`,
       data: teamName,
     })
     .catch(throwErrorMessage);
-};
 
 export const deleteTeam = (teamId: number) =>
   api
@@ -60,7 +54,7 @@ export const withdrawTeam = (teamId: number) =>
     })
     .catch(throwErrorMessage);
 
-export const deleteTeamMembers = (teamId: number, memberInfo: MemberElementType[]) =>
+export const deleteTeamMembers = (teamId: number, memberInfo: MemberElement[]) =>
   api
     .delete({
       url: `teams/${teamId}`,

--- a/src/api/team.ts
+++ b/src/api/team.ts
@@ -7,14 +7,44 @@ type MemberElementType = {
   grade: string;
 };
 
-export const deleteTeam = (teamId: number | undefined) =>
+interface TeamInfoProps {
+  image: Record<string, string>;
+  teamName: string;
+  teamBio: string;
+  teamSport: string;
+  teamAgeGroup: string;
+}
+
+export const createTeam = ({
+  image,
+  teamName,
+  teamBio,
+  teamSport,
+  teamAgeGroup,
+}: TeamInfoProps) => {
+  const postFormImage = new FormData();
+  postFormImage.append('logo', image.file);
+  postFormImage.append('teamName', teamName);
+  postFormImage.append('bio', teamBio);
+  postFormImage.append('sports', teamSport);
+  postFormImage.append('ageGroup', teamAgeGroup);
+
+  return api
+    .post({
+      url: '/teams',
+      data: postFormImage,
+    })
+    .catch(throwErrorMessage);
+};
+
+export const deleteTeam = (teamId: number) =>
   api
     .delete({
       url: `/teams/${teamId}`,
     })
     .catch(throwErrorMessage);
 
-export const withdrawTeam = (teamId: number | undefined) =>
+export const withdrawTeam = (teamId: number) =>
   api
     .delete({
       url: `/teams/${teamId}/me`,

--- a/src/api/team.ts
+++ b/src/api/team.ts
@@ -67,3 +67,24 @@ export const deleteTeamMembers = (teamId: number, memberInfo: MemberElementType[
       data: { memberInfo },
     })
     .catch(throwErrorMessage);
+
+export const getTeamInfo = (teamId: number) =>
+  api
+    .get({
+      url: `/teams/${teamId}`,
+    })
+    .catch(throwErrorMessage);
+
+export const getMemberInfo = (teamId: number) =>
+  api
+    .get({
+      url: `/teams/${teamId}/members`,
+    })
+    .catch(throwErrorMessage);
+
+export const getMatchHistory = (teamId: number) =>
+  api
+    .get({
+      url: `teams/${teamId}/matches`,
+    })
+    .catch(throwErrorMessage);

--- a/src/api/team.ts
+++ b/src/api/team.ts
@@ -37,6 +37,15 @@ export const createTeam = ({
     .catch(throwErrorMessage);
 };
 
+export const checkTeamNameDuplication = (teamName: string) => {
+  return api
+    .get({
+      url: `/teams/name-check`,
+      data: teamName,
+    })
+    .catch(throwErrorMessage);
+};
+
 export const deleteTeam = (teamId: number) =>
   api
     .delete({

--- a/src/components/TeamPlayerManage/MemberList/MemberList.tsx
+++ b/src/components/TeamPlayerManage/MemberList/MemberList.tsx
@@ -15,10 +15,11 @@ interface Props {
   memberInfo: MemberElementType[];
   hasAuthorization: boolean;
   isEditing: boolean;
+  hasCategoryTitle?: boolean;
   handleAddDeletedMembers?: React.MouseEventHandler<HTMLDivElement>;
-  handleChangeMemberGrade: React.ChangeEventHandler<HTMLSelectElement>;
-  handleSubmitDeletedMember: React.FormEventHandler<HTMLFormElement>;
-  handleChangeEditButtonStatus: React.MouseEventHandler<HTMLButtonElement>;
+  handleChangeMemberGrade?: React.ChangeEventHandler<HTMLSelectElement>;
+  handleSubmitDeletedMember?: React.FormEventHandler<HTMLFormElement>;
+  handleChangeEditButtonStatus?: React.MouseEventHandler<HTMLButtonElement>;
 }
 
 const { categoryTitle, playerDetailInfo } = style;
@@ -28,6 +29,7 @@ const MemberList = ({
   memberInfo,
   hasAuthorization,
   isEditing,
+  hasCategoryTitle,
   handleAddDeletedMembers,
   handleChangeMemberGrade,
   handleSubmitDeletedMember,
@@ -45,7 +47,9 @@ const MemberList = ({
       <form className={classNames(playerDetailInfo)} onSubmit={handleSubmitDeletedMember}>
         {/* article Header */}
         <div>
-          <p className={classNames(categoryTitle)}>{isMember ? '팀원' : '용병'} 정보</p>
+          {hasCategoryTitle && (
+            <p className={classNames(categoryTitle)}>{isMember ? '팀원' : '용병'} 정보</p>
+          )}
           {hasAuthorization && (
             <button type="button" onClick={handleChangeEditButtonStatus}>
               {isEditing ? '완료' : '수정'}

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,3 +1,4 @@
 export { default as DefaultTemplate } from './DefaultTemplate/DefaultTemplate';
 export * from './common';
 export * from './TeamPlayerManage';
+export * from './MatchDetail';

--- a/src/hooks/useForm.ts
+++ b/src/hooks/useForm.ts
@@ -1,4 +1,4 @@
-import React, { ChangeEvent, FormEvent, useState } from 'react';
+import React, { ChangeEvent, FormEvent, useState, useEffect } from 'react';
 
 interface UseFormArgs<T> {
   initialValues: T;
@@ -10,6 +10,12 @@ const useForm = <T>({ initialValues, onSubmit, validate }: UseFormArgs<T>) => {
   const [values, setValues] = useState<T>(initialValues);
   const [errors, setErrors] = useState<T>(initialValues);
   const [isLoading, setIsLoading] = useState(false);
+
+  useEffect(() => {
+    const newError = validate(values);
+    setErrors(newError);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [values]);
 
   const handleChange = (e: ChangeEvent<HTMLInputElement | HTMLSelectElement>) => {
     const { id, value } = e.target;

--- a/src/pages/MatchDetail/MatchDetail.tsx
+++ b/src/pages/MatchDetail/MatchDetail.tsx
@@ -36,11 +36,10 @@ const MatchDetail = () => {
   const hasEndReviewState = endReview.length !== 0;
 
   const updateTeamMatchHistory = useCallback(async () => {
-    const { data } = await getMatchHistory(teamId);
-    const { matchesSummary } = data;
+    const { matchesSummary } = await getMatchHistory(teamId);
 
     // TODO: 객체 배열을 검사해서, 다른 경우에만 업데이트 하는 로직으로 개선*
-    if (data.matchesSummary) {
+    if (matchesSummary) {
       setMatchHistory(matchesSummary);
     }
   }, [teamId]);

--- a/src/pages/MatchDetail/MatchDetail.tsx
+++ b/src/pages/MatchDetail/MatchDetail.tsx
@@ -1,159 +1,53 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import classNames from 'classnames';
 import { Tabs } from '@karrotframe/tabs';
+import { Link, useParams } from 'react-router-dom';
 import style from './matchDetail.module.scss';
-import { Header } from '@/components';
+import { Header, MatchListElement } from '@/components';
 import '@karrotframe/tabs/index.css';
-import { MatchListElement } from '@/components/MatchDetail';
-import api from '@/api/core';
+import { getMatchHistory } from '@/api';
+import { MatchElement } from '@/types';
 
 const { matchComponentContainer, mainTitle, highlight, titleContainer } = style;
 
-const DUMMY_DATA = [
-  {
-    matchId: 1,
-    matchDate: '2021-12-01',
-    registerTeamName: 't1',
-    registerTeamLogo: 'http://matchus.com/img/joLogo.img',
-    applyTeamName: 't2',
-    applyTeamLogo: 'http://matchus.com/img/joLogo.img',
-    status: 'previousMatch',
-  },
-  {
-    matchId: 2,
-    matchDate: '2021-11-29',
-    registerTeamName: 't1',
-    registerTeamLogo: 'http://matchus.com/img/joLogo.img',
-    applyTeamName: 't2',
-    applyTeamLogo: 'http://matchus.com/img/joLogo.img',
-    status: 'previousMatch',
-  },
-  {
-    matchId: 3,
-    matchDate: '2021-11-28',
-    registerTeamName: 't1',
-    registerTeamLogo: 'http://matchus.com/img/joLogo.img',
-    applyTeamName: 't2',
-    applyTeamLogo: 'http://matchus.com/img/joLogo.img',
-    status: 'previousMatch',
-  },
-  {
-    matchId: 4,
-    matchDate: '2021-10-01',
-    registerTeamName: 't1',
-    registerTeamLogo: 'http://matchus.com/img/joLogo.img',
-    applyTeamName: 't2',
-    applyTeamLogo: 'http://matchus.com/img/joLogo.img',
-    status: 'previousMatch',
-  },
-  {
-    matchId: 5,
-    matchDate: '2021-09-01',
-    registerTeamName: 't1',
-    registerTeamLogo: 'http://matchus.com/img/joLogo.img',
-    applyTeamName: 't2',
-    applyTeamLogo: 'http://matchus.com/img/joLogo.img',
-    status: 'previousReview',
-  },
-  {
-    matchId: 6,
-    matchDate: '2021-08-29',
-    registerTeamName: 't1',
-    registerTeamLogo: 'http://matchus.com/img/joLogo.img',
-    applyTeamName: 't2',
-    applyTeamLogo: 'http://matchus.com/img/joLogo.img',
-    status: 'previousReview',
-  },
-  {
-    matchId: 7,
-    matchDate: '2021-07-28',
-    registerTeamName: 't1',
-    registerTeamLogo: 'http://matchus.com/img/joLogo.img',
-    applyTeamName: 't2',
-    applyTeamLogo: 'http://matchus.com/img/joLogo.img',
-    status: 'previousReview',
-  },
-  {
-    matchId: 8,
-    matchDate: '2021-11-01',
-    registerTeamName: 't1',
-    registerTeamLogo: 'http://matchus.com/img/joLogo.img',
-    applyTeamName: 't2',
-    applyTeamLogo: 'http://matchus.com/img/joLogo.img',
-    status: 'endReview',
-  },
-  {
-    matchId: 9,
-    matchDate: '2021-06-27',
-    registerTeamName: 't1',
-    registerTeamLogo: 'http://matchus.com/img/joLogo.img',
-    applyTeamName: 't2',
-    applyTeamLogo: 'http://matchus.com/img/joLogo.img',
-    status: 'endReview',
-  },
-  {
-    matchId: 10,
-    matchDate: '2021-06-29',
-    registerTeamName: 't1',
-    registerTeamLogo: 'http://matchus.com/img/joLogo.img',
-    applyTeamName: 't2',
-    applyTeamLogo: 'http://matchus.com/img/joLogo.img',
-    status: 'endReview',
-  },
-  {
-    matchId: 11,
-    matchDate: '2021-05-05',
-    registerTeamName: 't1',
-    registerTeamLogo: 'http://matchus.com/img/joLogo.img',
-    applyTeamName: 't2',
-    applyTeamLogo: 'http://matchus.com/img/joLogo.img',
-    status: 'endReview',
-  },
-  {
-    matchId: 12,
-    matchDate: '2021-08-27',
-    registerTeamName: 't1',
-    registerTeamLogo: 'http://matchus.com/img/joLogo.img',
-    applyTeamName: 't2',
-    applyTeamLogo: 'http://matchus.com/img/joLogo.img',
-    status: 'endReview',
-  },
-];
-
 const MatchDetail = () => {
-  const [matchHistory, setMatchHistory] = useState();
+  const teamId = parseInt(useParams<{ teamId: string }>().teamId, 10);
+  const [matchHistory, setMatchHistory] = useState<MatchElement[]>([]);
 
-  const previousMatch = DUMMY_DATA.filter((match) => {
+  const previousMatch = matchHistory.filter((match) => {
     if (match.status === 'previousMatch') return true;
     return false;
   });
 
-  const previousReview = DUMMY_DATA.filter((match) => {
+  const previousReview = matchHistory.filter((match) => {
     if (match.status === 'previousReview') return true;
     return false;
   });
 
-  const endReview = DUMMY_DATA.filter((match) => {
+  const endReview = matchHistory.filter((match) => {
     if (match.status === 'endReview') return true;
     return false;
   });
 
   const [activeTabKey, setActiveTabKey] = useState<string>('beforeMatch');
 
+  const hasPreviousMatchState = previousMatch.length !== 0;
+  const hasPreviousReviewState = previousReview.length !== 0;
+  const hasEndReviewState = endReview.length !== 0;
+
+  const updateTeamMatchHistory = useCallback(async () => {
+    const { data } = await getMatchHistory(teamId);
+    const { matchesSummary } = data;
+
+    // TODO: 객체 배열을 검사해서, 다른 경우에만 업데이트 하는 로직으로 개선*
+    if (data.matchesSummary) {
+      setMatchHistory(matchesSummary);
+    }
+  }, [teamId]);
+
   useEffect(() => {
-    const teamId = window.location.pathname.split('/')[2];
-
-    const getTeamMatchHistory = async () => {
-      const { data } = await api.get({
-        url: `teams/${teamId}/matches`,
-      });
-
-      const { matchSucmmary } = data;
-      setMatchHistory(matchSucmmary);
-    };
-
-    getTeamMatchHistory();
-  }, [matchHistory, setMatchHistory]);
+    updateTeamMatchHistory();
+  }, [updateTeamMatchHistory]);
 
   return (
     <>
@@ -178,20 +72,30 @@ const MatchDetail = () => {
                 buttonLabel: '매칭 전',
                 render: () => (
                   <div>
-                    {previousMatch.map((match) => {
-                      return (
-                        <MatchListElement
-                          key={`beforeMatch-${match.matchId}`}
-                          matchId={match.matchId}
-                          matchDate={match.matchDate}
-                          registerTeamLogo={match.registerTeamLogo}
-                          registerTeamName={match.registerTeamName}
-                          applyTeamLogo={match.applyTeamLogo}
-                          applyTeamName={match.applyTeamName}
-                          status={match.status}
-                        />
-                      );
-                    })}
+                    {hasPreviousMatchState ? (
+                      previousMatch.map((match) => {
+                        return (
+                          <MatchListElement
+                            key={`beforeMatch-${match.matchId}`}
+                            matchId={match.matchId}
+                            matchDate={match.matchDate}
+                            registerTeamLogo={match.registerTeamLogo}
+                            registerTeamName={match.registerTeamName}
+                            applyTeamLogo={match.applyTeamLogo}
+                            applyTeamName={match.applyTeamName}
+                            status={match.status}
+                          />
+                        );
+                      })
+                    ) : (
+                      <p>
+                        <span className={classNames('whiteSpace')}>경기일정이 없습니다.</span>
+                        <span className={classNames('whiteSpace')}>
+                          경기 모집 글을 올리러 가볼까요?
+                        </span>
+                        <Link to="/teams">경기 등록</Link>
+                      </p>
+                    )}
                   </div>
                 ),
               },
@@ -200,20 +104,24 @@ const MatchDetail = () => {
                 buttonLabel: '평가 전',
                 render: () => (
                   <div>
-                    {previousReview.map((match) => {
-                      return (
-                        <MatchListElement
-                          key={`beforeReview-${match.matchId}`}
-                          matchId={match.matchId}
-                          matchDate={match.matchDate}
-                          registerTeamLogo={match.registerTeamLogo}
-                          registerTeamName={match.registerTeamName}
-                          applyTeamLogo={match.applyTeamLogo}
-                          applyTeamName={match.applyTeamName}
-                          status={match.status}
-                        />
-                      );
-                    })}
+                    {hasPreviousReviewState ? (
+                      previousReview.map((match) => {
+                        return (
+                          <MatchListElement
+                            key={`beforeReview-${match.matchId}`}
+                            matchId={match.matchId}
+                            matchDate={match.matchDate}
+                            registerTeamLogo={match.registerTeamLogo}
+                            registerTeamName={match.registerTeamName}
+                            applyTeamLogo={match.applyTeamLogo}
+                            applyTeamName={match.applyTeamName}
+                            status={match.status}
+                          />
+                        );
+                      })
+                    ) : (
+                      <div>모든 평가가 완료되었습니다🥳</div>
+                    )}
                   </div>
                 ),
               },
@@ -222,20 +130,24 @@ const MatchDetail = () => {
                 buttonLabel: '평가 후',
                 render: () => (
                   <div>
-                    {endReview.map((match) => {
-                      return (
-                        <MatchListElement
-                          key={`afterReview-${match.matchId}`}
-                          matchId={match.matchId}
-                          matchDate={match.matchDate}
-                          registerTeamLogo={match.registerTeamLogo}
-                          registerTeamName={match.registerTeamName}
-                          applyTeamLogo={match.applyTeamLogo}
-                          applyTeamName={match.applyTeamName}
-                          status={match.status}
-                        />
-                      );
-                    })}
+                    {hasEndReviewState ? (
+                      endReview.map((match) => {
+                        return (
+                          <MatchListElement
+                            key={`afterReview-${match.matchId}`}
+                            matchId={match.matchId}
+                            matchDate={match.matchDate}
+                            registerTeamLogo={match.registerTeamLogo}
+                            registerTeamName={match.registerTeamName}
+                            applyTeamLogo={match.applyTeamLogo}
+                            applyTeamName={match.applyTeamName}
+                            status={match.status}
+                          />
+                        );
+                      })
+                    ) : (
+                      <div>평가 완료된 경기가 없습니다 🥵</div>
+                    )}
                   </div>
                 ),
               },

--- a/src/pages/MatchDetail/MatchDetail.tsx
+++ b/src/pages/MatchDetail/MatchDetail.tsx
@@ -14,20 +14,9 @@ const MatchDetail = () => {
   const teamId = parseInt(useParams<{ teamId: string }>().teamId, 10);
   const [matchHistory, setMatchHistory] = useState<MatchElement[]>([]);
 
-  const previousMatch = matchHistory.filter((match) => {
-    if (match.status === 'previousMatch') return true;
-    return false;
-  });
-
-  const previousReview = matchHistory.filter((match) => {
-    if (match.status === 'previousReview') return true;
-    return false;
-  });
-
-  const endReview = matchHistory.filter((match) => {
-    if (match.status === 'endReview') return true;
-    return false;
-  });
+  const previousMatch = matchHistory.filter((match) => match.status === 'previousMatch');
+  const previousReview = matchHistory.filter((match) => match.status === 'previousReview');
+  const endReview = matchHistory.filter((match) => match.status === 'endReview');
 
   const [activeTabKey, setActiveTabKey] = useState<string>('beforeMatch');
 

--- a/src/pages/TeamCreate/TeamCreate.tsx
+++ b/src/pages/TeamCreate/TeamCreate.tsx
@@ -1,4 +1,4 @@
-import React, { ChangeEvent } from 'react';
+import React, { ChangeEvent, useState } from 'react';
 import classNames from 'classnames';
 import { useHistory } from 'react-router-dom';
 import { SPORTS_CATEGORY, AGE_GROUP } from '@/consts';
@@ -11,15 +11,11 @@ import {
   validateTeamNameLength,
   validateTeamNameHasSpace,
 } from '@/utils/validation/validation';
-import { createTeam } from '@/api';
-
-const handleSubmitTeamInfo = (e: React.FormEvent<HTMLFormElement>) => {
-  // TODO: API 구현 완료 시, 본 handler를 통해서 통신 할 예정
-  e.preventDefault();
-};
+import { createTeam, checkTeamNameDuplication } from '@/api';
 
 const TeamCreate = () => {
   const history = useHistory();
+  const [isDuplicatedTeamName, setIsDuplicatedTeamName] = useState<boolean>(true);
 
   const initialValues = {
     image: {
@@ -35,8 +31,7 @@ const TeamCreate = () => {
   const { values, setValues, errors, isLoading, handleChange, handleSubmit } = useForm({
     initialValues,
     onSubmit: async ({ image, teamName, teamBio, teamSport, teamAgeGroup }) => {
-      const result = await createTeam({ image, teamName, teamBio, teamSport, teamAgeGroup });
-      const { data } = result;
+      const { data } = await createTeam({ image, teamName, teamBio, teamSport, teamAgeGroup });
 
       if (data.teamId) {
         history.push(`/teams/${data.teamId}`);
@@ -95,6 +90,17 @@ const TeamCreate = () => {
     readImageFileAsUrl({ name, files });
   };
 
+  const handleCheckTeamNameDuplication = async () => {
+    const { data } = await checkTeamNameDuplication(values.teamName);
+
+    if (data.success) {
+      alert('사용 하셔도 좋습니다.');
+      setIsDuplicatedTeamName(false);
+    }
+    alert('중복된 팀 이름이 존재합니다.');
+    setIsDuplicatedTeamName(true);
+  };
+
   const isDisabled = !!Object.keys(errors).length;
 
   return (
@@ -120,8 +126,21 @@ const TeamCreate = () => {
             placeholder="팀 이름을 작성해 주세요"
             onChange={handleChange}
           />
+          {isDuplicatedTeamName ? (
+            <button
+              type="button"
+              onClick={handleCheckTeamNameDuplication}
+              disabled={!!errors.teamName}
+            >
+              중복 확인
+            </button>
+          ) : (
+            <button type="button" disabled>
+              완료 🎉
+            </button>
+          )}
         </div>
-        {isDisabled ? <p>{errors.teamName}</p> : ''}
+        {values.teamName && errors.teamName ? <p>{errors.teamName}</p> : ''}
         <div>
           <CustomLabel htmlFor="teamBio">팀 설명</CustomLabel>
           <CustomInput
@@ -131,7 +150,7 @@ const TeamCreate = () => {
             onChange={handleChange}
           />
         </div>
-        {isDisabled ? <p>{errors.teamBio}</p> : ''}
+        {errors.teamBio ? <p>{errors.teamBio}</p> : ''}
         <div>
           <CustomLabel htmlFor="teamSport">종목</CustomLabel>
           <select id="teamSport" onChange={handleChange}>
@@ -143,7 +162,7 @@ const TeamCreate = () => {
             ))}
           </select>
         </div>
-        {isDisabled ? <p>{errors.teamSport}</p> : ''}
+        {values.teamSport && errors.teamSport ? <p>{errors.teamSport}</p> : ''}
         <div>
           <CustomLabel htmlFor="teamAgeGroup">연령대</CustomLabel>
           <select id="teamAgeGroup" onChange={handleChange}>
@@ -155,8 +174,8 @@ const TeamCreate = () => {
             ))}
           </select>
         </div>
-        {isDisabled ? <p>{errors.teamAgeGroup}</p> : ''}
-        <CustomButton buttonType="submit" isDisabled={isLoading}>
+        {values.teamAgeGroup && errors.teamAgeGroup ? <p>{errors.teamAgeGroup}</p> : ''}
+        <CustomButton buttonType="submit" isDisabled={isDisabled}>
           생성
         </CustomButton>
       </form>

--- a/src/pages/TeamCreate/TeamCreate.tsx
+++ b/src/pages/TeamCreate/TeamCreate.tsx
@@ -37,7 +37,7 @@ const TeamCreate = () => {
         history.push(`/teams/${teamId}`);
       }
     },
-    validate: ({ teamName, teamBio, teamSport, teamAgeGroup }) => {
+    validate: ({ image, teamName, teamBio, teamSport, teamAgeGroup }) => {
       const newErros = {} as any;
 
       if (!validateTeamName(teamName)) {
@@ -54,6 +54,10 @@ const TeamCreate = () => {
 
       if (!validateTeamBioLength(teamBio)) {
         newErros.teamBio = TEAM_VALID_ERROR_MSG.IS_VALID_BIO_LEN;
+      }
+
+      if (image.file === '') {
+        newErros.image = TEAM_VALID_ERROR_MSG.HAS_TEAM_LOGO_IMAGE;
       }
 
       if (!teamSport) {

--- a/src/pages/TeamCreate/TeamCreate.tsx
+++ b/src/pages/TeamCreate/TeamCreate.tsx
@@ -101,7 +101,7 @@ const TeamCreate = () => {
     setIsDuplicatedTeamName(true);
   };
 
-  const isDisabled = !!Object.keys(errors).length;
+  const isDisabled = !!Object.keys(errors).length || isLoading;
 
   return (
     <>

--- a/src/pages/TeamCreate/TeamCreate.tsx
+++ b/src/pages/TeamCreate/TeamCreate.tsx
@@ -1,5 +1,6 @@
 import React, { ChangeEvent } from 'react';
 import classNames from 'classnames';
+import { useHistory } from 'react-router-dom';
 import { SPORTS_CATEGORY, AGE_GROUP } from '@/consts';
 import { CustomButton, CustomInput, CustomLabel } from '@/components';
 import useForm from '@/hooks/useForm';
@@ -10,6 +11,7 @@ import {
   validateTeamNameLength,
   validateTeamNameHasSpace,
 } from '@/utils/validation/validation';
+import { createTeam } from '@/api';
 
 const handleSubmitTeamInfo = (e: React.FormEvent<HTMLFormElement>) => {
   // TODO: API 구현 완료 시, 본 handler를 통해서 통신 할 예정
@@ -17,6 +19,8 @@ const handleSubmitTeamInfo = (e: React.FormEvent<HTMLFormElement>) => {
 };
 
 const TeamCreate = () => {
+  const history = useHistory();
+
   const initialValues = {
     image: {
       url: '',
@@ -30,7 +34,14 @@ const TeamCreate = () => {
 
   const { values, setValues, errors, isLoading, handleChange, handleSubmit } = useForm({
     initialValues,
-    onSubmit: () => {},
+    onSubmit: async ({ image, teamName, teamBio, teamSport, teamAgeGroup }) => {
+      const result = await createTeam({ image, teamName, teamBio, teamSport, teamAgeGroup });
+      const { data } = result;
+
+      if (data.teamId) {
+        history.push(`/teams/${data.teamId}`);
+      }
+    },
     validate: ({ teamName, teamBio, teamSport, teamAgeGroup }) => {
       const newErros = {} as any;
 
@@ -90,7 +101,7 @@ const TeamCreate = () => {
     <>
       <header />
       <form onSubmit={handleSubmit}>
-        <h1 className={classNames('s_a11yHidden')}>팀 생성 페이지</h1>
+        <h1 className={classNames('a11yHidden')}>팀 생성 페이지</h1>
         <p>멋진 팀을 만들어 볼까요?</p>
         <img src={values.image.url} alt="이미지" />
         <input

--- a/src/pages/TeamCreate/TeamCreate.tsx
+++ b/src/pages/TeamCreate/TeamCreate.tsx
@@ -31,10 +31,10 @@ const TeamCreate = () => {
   const { values, setValues, errors, isLoading, handleChange, handleSubmit } = useForm({
     initialValues,
     onSubmit: async ({ image, teamName, teamBio, teamSport, teamAgeGroup }) => {
-      const { data } = await createTeam({ image, teamName, teamBio, teamSport, teamAgeGroup });
+      const { teamId } = await createTeam({ image, teamName, teamBio, teamSport, teamAgeGroup });
 
-      if (data.teamId) {
-        history.push(`/teams/${data.teamId}`);
+      if (teamId) {
+        history.push(`/teams/${teamId}`);
       }
     },
     validate: ({ teamName, teamBio, teamSport, teamAgeGroup }) => {
@@ -91,9 +91,9 @@ const TeamCreate = () => {
   };
 
   const handleCheckTeamNameDuplication = async () => {
-    const { data } = await checkTeamNameDuplication(values.teamName);
+    const result = await checkTeamNameDuplication(values.teamName);
 
-    if (data.success) {
+    if (result.success) {
       alert('사용 하셔도 좋습니다.');
       setIsDuplicatedTeamName(false);
     }

--- a/src/pages/TeamDetail/TeamDetail.tsx
+++ b/src/pages/TeamDetail/TeamDetail.tsx
@@ -131,7 +131,13 @@ const TeamDetail = () => {
               hasCategoryTitle={false}
             />
           ) : (
-            <div>팀원이 없습니다.</div>
+            <p>
+              <span className={classNames('whiteSpace')}>팀원이이 없습니다.</span>
+              <span className={classNames('whiteSpace')}>
+                열정 가득한 팀원을 모집하러 가볼까요?
+              </span>
+              <Link to="/teams">팀원 모집</Link>
+            </p>
           )}
         </div>
       </article>
@@ -151,7 +157,11 @@ const TeamDetail = () => {
               hasCategoryTitle={false}
             />
           ) : (
-            <div>팀원이 없습니다.</div>
+            <p>
+              <span className={classNames('whiteSpace')}>용병이 없습니다.</span>
+              <span className={classNames('whiteSpace')}>멋진 용병을 모집하러 가볼까요?</span>
+              <Link to="/teams">용병 모집</Link>
+            </p>
           )}
         </div>
       </article>
@@ -178,7 +188,11 @@ const TeamDetail = () => {
             );
           })
         ) : (
-          <div>매칭 정보가 없습니다</div>
+          <p>
+            <span className={classNames('whiteSpace')}>경기일정이 없습니다.</span>
+            <span className={classNames('whiteSpace')}>경기 모집 글을 올리러 가볼까요?</span>
+            <Link to="/teams">경기 등록</Link>
+          </p>
         )}
       </article>
 

--- a/src/pages/TeamDetail/TeamDetail.tsx
+++ b/src/pages/TeamDetail/TeamDetail.tsx
@@ -66,14 +66,13 @@ const TeamDetail = () => {
   };
 
   const updateTeamInfo = useCallback(async () => {
-    const { data } = await getTeamInfo(teamId);
+    const result = await getTeamInfo(teamId);
 
-    setTeamInfo(data);
+    setTeamInfo(result);
   }, [teamId]);
 
   const updateMemberInfo = useCallback(async () => {
-    const { data } = await getMemberInfo(teamId);
-    const { member } = data;
+    const { member } = await getMemberInfo(teamId);
 
     if (member) {
       setMemberInfo(member);
@@ -81,10 +80,9 @@ const TeamDetail = () => {
   }, [teamId]);
 
   const updateTeamMatchHistory = useCallback(async () => {
-    const { data } = await getMatchHistory(teamId);
-    const { matchesSummary } = data;
+    const { matchesSummary } = await getMatchHistory(teamId);
 
-    if (data.matchesSummary) {
+    if (matchesSummary) {
       setMatchHistory(matchesSummary);
     }
   }, [teamId]);

--- a/src/pages/TeamDetail/TeamDetail.tsx
+++ b/src/pages/TeamDetail/TeamDetail.tsx
@@ -1,11 +1,12 @@
 /* eslint-disable no-restricted-globals */
 import classNames from 'classnames';
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import { Link, useParams } from 'react-router-dom';
 import style from './teamDetail.module.scss';
-import api from '@/api/core';
-import { throwErrorMessage } from '@/utils';
-import { deleteTeam, withdrawTeam } from '@/api';
+
+import { deleteTeam, withdrawTeam, getTeamInfo, getMemberInfo, getMatchHistory } from '@/api';
+import { MemberElement, MatchElement } from '@/types';
+import { MemberList, MatchListElement } from '@/components';
 
 const { teamBaseInfo, logImage, teamCoreInfo, teamMemberInfo, hiredMemberInfo, teamMathchesInfo } =
   style;
@@ -21,24 +22,22 @@ const TeamDetail = () => {
     sportsName: '',
     tagNames: [],
     matchCount: 0,
-    manner_temperature: 0,
+    mannerTemperature: 0,
     captainId: 0,
     captainName: '',
     ageGroup: '',
     teamCreatedAt: '',
-    teamMembers: [{ userId: 0, userName: '', grade: '' }],
-    hiredMembers: [{ userId: 0, userName: '', grade: '' }],
-    matchesSummary: [
-      {
-        matchId: 0,
-        matchDate: '',
-        registerTeamName: '',
-        registerTeamLogo: '',
-        applyTeamName: '',
-        applyTeamLogo: '',
-      },
-    ],
   });
+  const [memberInfo, setMemberInfo] = useState<MemberElement[]>([]);
+  const [matchHistory, setMatchHistory] = useState<MatchElement[]>([]);
+
+  const previousMatchHistory = matchHistory.filter((match) => {
+    if (match.status === 'previousMatch') return true;
+    return false;
+  });
+
+  const hasMember = memberInfo.length !== 0;
+  const hasPreviousMatchHistory = previousMatchHistory.length !== 0;
 
   const {
     teamName,
@@ -46,17 +45,13 @@ const TeamDetail = () => {
     sportsName,
     tagNames,
     matchCount,
-    manner_temperature,
+    mannerTemperature,
     captainId,
     captainName,
     ageGroup,
     teamCreatedAt,
-    teamMembers,
-    hiredMembers,
-    matchesSummary,
   } = teamInfo;
 
-  //
   const handleWithdrawTeam = () => {
     // TODO: Modal Component Merge되면 교체 예정.
     if (confirm('정말 삭제하시겠습니까?')) {
@@ -70,21 +65,35 @@ const TeamDetail = () => {
     }
   };
 
-  useEffect(() => {
-    const getTeamInfo = async (id: number) => {
-      if (id) {
-        const { data } = await api
-          .get({
-            url: `/team/${id}`,
-          })
-          .catch(throwErrorMessage);
+  const updateTeamInfo = useCallback(async () => {
+    const { data } = await getTeamInfo(teamId);
 
-        setTeamInfo(data);
-      }
-    };
-
-    getTeamInfo(teamId);
+    setTeamInfo(data);
   }, [teamId]);
+
+  const updateMemberInfo = useCallback(async () => {
+    const { data } = await getMemberInfo(teamId);
+    const { member } = data;
+
+    if (member) {
+      setMemberInfo(member);
+    }
+  }, [teamId]);
+
+  const updateTeamMatchHistory = useCallback(async () => {
+    const { data } = await getMatchHistory(teamId);
+    const { matchesSummary } = data;
+
+    if (data.matchesSummary) {
+      setMatchHistory(matchesSummary);
+    }
+  }, [teamId]);
+
+  useEffect(() => {
+    updateTeamInfo();
+    updateTeamMatchHistory();
+    updateMemberInfo();
+  }, [updateTeamInfo, updateMemberInfo, updateTeamMatchHistory]);
 
   return (
     <div>
@@ -100,7 +109,7 @@ const TeamDetail = () => {
 
       <article className={classNames(teamCoreInfo)}>
         <section>총 경기 수{matchCount}</section>
-        <section>매너온도 {manner_temperature}</section>
+        <section>매너온도 {mannerTemperature}</section>
         <section id={`captain-${captainId}`}>{`운영진 ${captainName}`}</section>
         <section>주요 종목 {sportsName}</section>
         <section>연령대 {ageGroup}</section>
@@ -113,9 +122,17 @@ const TeamDetail = () => {
           <Link to={`/team/${teamId}/member`}>더보기</Link>
         </div>
         <div>
-          {teamMembers.map((member) => (
-            <div key={`member-${member.userId}`}>{member.userName}</div>
-          ))}
+          {hasMember ? (
+            <MemberList
+              isMember
+              memberInfo={memberInfo}
+              hasAuthorization={false}
+              isEditing={false}
+              hasCategoryTitle={false}
+            />
+          ) : (
+            <div>팀원이 없습니다.</div>
+          )}
         </div>
       </article>
 
@@ -125,20 +142,44 @@ const TeamDetail = () => {
           <Link to={`/team/${teamId}/hired`}>더보기</Link>
         </div>
         <div>
-          {hiredMembers.map((member) => (
-            <div key={`member-${member.userId}`}>{member.userName}</div>
-          ))}
+          {hasMember ? (
+            <MemberList
+              isMember={false}
+              memberInfo={memberInfo}
+              hasAuthorization={false}
+              isEditing={false}
+              hasCategoryTitle={false}
+            />
+          ) : (
+            <div>팀원이 없습니다.</div>
+          )}
         </div>
       </article>
 
       {/* TODO: 매칭 리스트 상세보기 할 때, 추상화된 컴포넌트 만들 예정 */}
       <article className={classNames(teamMathchesInfo)}>
-        {matchesSummary.map((match) => (
-          <section key={`match-${match.matchId}`}>
-            <img src={match.registerTeamLogo} alt="등록 팀 로고" />
-            <img src={match.applyTeamLogo} alt="신청 팀 로고" />
-          </section>
-        ))}
+        <div>
+          매칭 목록
+          <Link to={`/team/${teamId}/hired`}>더보기</Link>
+        </div>
+        {hasPreviousMatchHistory ? (
+          previousMatchHistory.map((match) => {
+            return (
+              <MatchListElement
+                key={`beforeMatch-${match.matchId}`}
+                matchId={match.matchId}
+                matchDate={match.matchDate}
+                registerTeamLogo={match.registerTeamLogo}
+                registerTeamName={match.registerTeamName}
+                applyTeamLogo={match.applyTeamLogo}
+                applyTeamName={match.applyTeamName}
+                status={match.status}
+              />
+            );
+          })
+        ) : (
+          <div>매칭 정보가 없습니다</div>
+        )}
       </article>
 
       <button type="button" onClick={hasAuthorization ? handleDeleteTeam : handleWithdrawTeam}>

--- a/src/pages/TeamInfoEdit/TeamInfoEdit.tsx
+++ b/src/pages/TeamInfoEdit/TeamInfoEdit.tsx
@@ -5,11 +5,6 @@ import { CustomButton, CustomInput, CustomLabel } from '@/components';
 import useForm from '@/hooks/useForm';
 import { validateTeamBioLength, TEAM_VALID_ERROR_MSG } from '@/utils/validation/validation';
 
-const handleEditTeamInfo = (e: React.FormEvent<HTMLFormElement>) => {
-  // TODO: API 구현 완료 시, 본 handler를 통해서 통신 할 예정
-  e.preventDefault();
-};
-
 const TeamInfoEdit = () => {
   const initialValues = {
     image: {

--- a/src/pages/TeamInfoEdit/TeamInfoEdit.tsx
+++ b/src/pages/TeamInfoEdit/TeamInfoEdit.tsx
@@ -1,11 +1,14 @@
 import React, { ChangeEvent } from 'react';
 import classNames from 'classnames';
+import { useHistory, useParams } from 'react-router-dom';
 import { SPORTS_CATEGORY, AGE_GROUP } from '@/consts';
 import { CustomButton, CustomInput, CustomLabel } from '@/components';
 import useForm from '@/hooks/useForm';
 import { validateTeamBioLength, TEAM_VALID_ERROR_MSG } from '@/utils/validation/validation';
+import { editTeamInfo } from '@/api';
 
 const TeamInfoEdit = () => {
+  const history = useHistory();
   const initialValues = {
     image: {
       url: '',
@@ -15,19 +18,22 @@ const TeamInfoEdit = () => {
     teamSport: '',
     teamAgeGroup: '',
   };
+  const teamId = parseInt(useParams<{ teamId: string }>().teamId, 10);
 
   const { values, setValues, errors, isLoading, handleChange, handleSubmit } = useForm({
     initialValues,
-    onSubmit: () => {},
-    validate: ({ teamBio, teamSport, teamAgeGroup }) => {
+    onSubmit: async ({ image, teamBio, teamAgeGroup }) => {
+      const result = await editTeamInfo({ image, teamBio, teamAgeGroup, teamId });
+
+      if (result.teamId) {
+        history.push(`/teams/${result.teamId}`);
+      }
+    },
+    validate: ({ teamBio, teamAgeGroup }) => {
       const newErros = {} as any;
 
       if (!validateTeamBioLength(teamBio)) {
         newErros.teamBio = TEAM_VALID_ERROR_MSG.IS_VALID_BIO_LEN;
-      }
-
-      if (!teamSport) {
-        newErros.teamSport = TEAM_VALID_ERROR_MSG.IS_TEAM_SPORT;
       }
 
       if (!teamAgeGroup) {
@@ -60,7 +66,7 @@ const TeamInfoEdit = () => {
     readImageFileAsUrl({ name, files });
   };
 
-  const isDisabled = !!Object.keys(errors).length;
+  const isDisabled = !!Object.keys(errors).length || isLoading;
 
   return (
     <>
@@ -87,18 +93,6 @@ const TeamInfoEdit = () => {
         </div>
         {isDisabled ? <p>{errors.teamBio}</p> : ''}
         <div>
-          <CustomLabel htmlFor="teamSportCategory">종목</CustomLabel>
-          <select id="teamSportCategory" onChange={handleChange}>
-            <option>종목</option>
-            {SPORTS_CATEGORY.map((category) => (
-              <option id={`team-${category.id}`} key={`team-${category.id}`}>
-                {category.name}
-              </option>
-            ))}
-          </select>
-        </div>
-        {isDisabled ? <p>{errors.teamSport}</p> : ''}
-        <div>
           <CustomLabel htmlFor="teamAgeGroup">연령대</CustomLabel>
           <select id="teamAgeGroup" onChange={handleChange}>
             <option>연령대</option>
@@ -109,8 +103,8 @@ const TeamInfoEdit = () => {
             ))}
           </select>
         </div>
-        {isDisabled ? <p>{errors.teamAgeGroup}</p> : ''}
-        <CustomButton buttonType="submit" isDisabled={isLoading}>
+        {values.teamAgeGroup && errors.teamAgeGroup ? <p>{errors.teamAgeGroup}</p> : ''}
+        <CustomButton buttonType="submit" isDisabled={isDisabled}>
           팀 정보 수정
         </CustomButton>
       </form>

--- a/src/pages/TeamInfoEdit/TeamInfoEdit.tsx
+++ b/src/pages/TeamInfoEdit/TeamInfoEdit.tsx
@@ -29,11 +29,15 @@ const TeamInfoEdit = () => {
         history.push(`/teams/${result.teamId}`);
       }
     },
-    validate: ({ teamBio, teamAgeGroup }) => {
+    validate: ({ image, teamBio, teamAgeGroup }) => {
       const newErros = {} as any;
 
       if (!validateTeamBioLength(teamBio)) {
         newErros.teamBio = TEAM_VALID_ERROR_MSG.IS_VALID_BIO_LEN;
+      }
+
+      if (image.file === '') {
+        newErros.image = TEAM_VALID_ERROR_MSG.HAS_TEAM_LOGO_IMAGE;
       }
 
       if (!teamAgeGroup) {

--- a/src/pages/TeamMemberManage/TeamMemberManage.tsx
+++ b/src/pages/TeamMemberManage/TeamMemberManage.tsx
@@ -168,10 +168,10 @@ const TeamMemberManage = () => {
     // }
     // TODO: API 연결 시, 주석 제거 예정
     // const getPeopleInfo = async () => {
-    //   const { data } = await api.get({
+    //   const result= await api.get({
     //     url: `/teams/${teamId}/${memberType}`,
     //   });
-    //   setMemberInfo(data);
+    //   setMemberInfo(result);
     // };
     // getPeopleInfo();
   }, []);

--- a/src/types/Team/Team.ts
+++ b/src/types/Team/Team.ts
@@ -1,0 +1,15 @@
+export interface MemberElement {
+  userId: number;
+  userName: string;
+  grade: string;
+}
+
+export interface MatchElement {
+  matchId: number;
+  matchDate: string;
+  registerTeamName: string;
+  registerTeamLogo: string;
+  applyTeamName: string;
+  applyTeamLogo: string;
+  status: string;
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,0 +1,1 @@
+export * from './Team/Team';

--- a/src/utils/validation/validation.ts
+++ b/src/utils/validation/validation.ts
@@ -1,6 +1,6 @@
 // 팀 이름 REGEX
 export const TEAM_REGEX = {
-  IS_VALID_NAME: /^[가-힣\s|ㄱ-ㅎ|a-z|A-Z|0-9]+$/g,
+  IS_VALID_NAME: /^[ㄱ-ㅎ|가-힣|a-z|A-Z|0-9|\*]+$/,
   HAS_SPACE_BAR: /\s/g,
   MIN_LEN: 1,
   MAX_LEN: 10,

--- a/src/utils/validation/validation.ts
+++ b/src/utils/validation/validation.ts
@@ -14,6 +14,7 @@ export const TEAM_VALID_ERROR_MSG = {
   IS_VALID_BIO_LEN: '세부 설명은 200자 이하로 작성해야합니다.',
   IS_TEAM_SPORT: '팀 종목을 선택해 주세요.',
   IS_TEAM_AGE_GROUP: '팀 연령대를 선택해 주세요.',
+  HAS_TEAM_LOGO_IMAGE: '사진을 첨부해 주세요',
 };
 
 export const validateTeamName = (teamName: string) => TEAM_REGEX.IS_VALID_NAME.test(teamName);


### PR DESCRIPTION
## 체크리스트
- [x] 팀 생성 API 연결
- [x] 팀 정보 조회 => 팀 상세 페이지 뷰 API 연결
- [x] 팀 정보 수정 API 연결
- [x] 팀 매칭 리스트 조회 API 연결
- [x] 팀원 조회 API 연결
 
## 팀원들에게 ✉️

팀 상세페이지에서 API 데이터가 없으면, 그 데이터를 추가할 수 있는 곳으로 이동하는 뷰를 만들어놨어요!
근데, 아직 다른 분들이 생각하는 url 주소를 몰라서 `/team` 으로 고정이 되어있을겁니다. 
이 부분은 무시하고, 코드리뷰 해주시면 감사드릴 것 같아요~~!