### PR TITLE
refactor: 용병 리스트에서 api에서 받은 용병 신청글로 뷰에 출력, 신청글 누르면 상세페이지 이동 (MAT-232)

### DIFF
--- a/src/components/Post/PostItem/PostItem.tsx
+++ b/src/components/Post/PostItem/PostItem.tsx
@@ -37,7 +37,7 @@ const PostItem = ({ item }: Post) => {
   const history = useHistory();
 
   const handleClickPostItme = () => {
-    history.push(`hires/${postId}`);
+    history.push(`/hires/${postId}`);
   };
 
   return (

--- a/src/components/Post/PostItem/PostItem.tsx
+++ b/src/components/Post/PostItem/PostItem.tsx
@@ -1,5 +1,8 @@
+/* eslint-disable jsx-a11y/click-events-have-key-events */
+/* eslint-disable jsx-a11y/no-noninteractive-element-interactions */
 import React from 'react';
 import classNames from 'classnames';
+import { useHistory } from 'react-router-dom';
 import style from './postItem.module.scss';
 
 import { Post } from '@/store/posts';
@@ -31,9 +34,15 @@ const PostItem = ({ item }: Post) => {
    * (2021-12-14)
    */
 
+  const history = useHistory();
+
+  const handleClickPostItme = () => {
+    history.push(`hires/${postId}`);
+  };
+
   return (
     <>
-      <li>
+      <li onClick={handleClickPostItme}>
         <article className={classNames(card)}>
           <section className={classNames(gameInfos)}>
             <img src={teamLogo} alt={`team logo ${isMatching ? matchId : postId}`} />

--- a/src/components/Post/Posts/Posts.tsx
+++ b/src/components/Post/Posts/Posts.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import classNames from 'classnames';
 
+import { useHistory } from 'react-router-dom';
 import { PostItem } from '..';
 import style from './posts.module.scss';
 import { PostWrapper } from '@/store/posts';
@@ -10,6 +11,11 @@ const { postTitle } = style;
 const Posts = ({ isMatch, selectedTeam, data }: PostWrapper) => {
   const { grade } = selectedTeam;
   const hasAuthority = grade.includes('CAPTAIN');
+  const history = useHistory();
+
+  const handleClickAddPosting = () => {
+    history.push(`/hires/post/new`);
+  };
 
   return (
     <>
@@ -27,7 +33,11 @@ const Posts = ({ isMatch, selectedTeam, data }: PostWrapper) => {
           />
         ))}
       </ul>
-      {hasAuthority && <button type="button">추가</button>}
+      {hasAuthority && (
+        <button type="button" onClick={handleClickAddPosting}>
+          추가
+        </button>
+      )}
     </>
   );
 };

--- a/src/components/Post/Posts/Posts.tsx
+++ b/src/components/Post/Posts/Posts.tsx
@@ -1,16 +1,13 @@
 import React from 'react';
-import { useSelector } from 'react-redux';
 import classNames from 'classnames';
 
-import { RootState } from '@/store/index';
 import { PostItem } from '..';
 import style from './posts.module.scss';
 import { PostWrapper } from '@/store/posts';
 
 const { postTitle } = style;
 
-const Posts = ({ isMatch, selectedTeam }: PostWrapper) => {
-  const { data } = useSelector((state: RootState) => state.posts);
+const Posts = ({ isMatch, selectedTeam, data }: PostWrapper) => {
   const { grade } = selectedTeam;
   const hasAuthority = grade.includes('CAPTAIN');
 

--- a/src/pages/Hires/Hires.tsx
+++ b/src/pages/Hires/Hires.tsx
@@ -4,7 +4,7 @@ import { fetchAllPost, HiresResponseType } from '@/store/posts';
 import { Posts } from '@/components';
 import { getHiresInfo } from '@/api/hires';
 // Todo(홍중) : 임시 데이터, 팀 정보 관리하는곳에서 가져오기(12/13)
-const selectedTeam = { teamId: 3, grade: 'GENERAL' };
+const selectedTeam = { teamId: 3, grade: 'CAPTAIN' };
 
 const Hires = () => {
   const dispatch = useDispatch();

--- a/src/pages/Hires/Hires.tsx
+++ b/src/pages/Hires/Hires.tsx
@@ -1,6 +1,6 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useDispatch } from 'react-redux';
-import { fetchAllPost } from '@/store/posts';
+import { fetchAllPost, HiresResponseType } from '@/store/posts';
 import { Posts } from '@/components';
 import { getHiresInfo } from '@/api/hires';
 // Todo(홍중) : 임시 데이터, 팀 정보 관리하는곳에서 가져오기(12/13)
@@ -8,6 +8,7 @@ const selectedTeam = { teamId: 3, grade: 'GENERAL' };
 
 const Hires = () => {
   const dispatch = useDispatch();
+  const [data, setData] = useState<Array<HiresResponseType>>([]);
 
   useEffect(() => {
     dispatch(fetchAllPost());
@@ -19,12 +20,14 @@ const Hires = () => {
       const params = {
         size: defaultSize,
       };
-      const res = await getHiresInfo(params);
+
+      const { hirePosts } = await getHiresInfo(params);
+      setData(hirePosts);
     };
 
     getCurrentHiresInfo();
   }, []);
-  return <Posts isMatch={false} selectedTeam={selectedTeam} />;
+  return <Posts isMatch={false} selectedTeam={selectedTeam} data={data} />;
 };
 
 export default Hires;

--- a/src/store/posts/index.ts
+++ b/src/store/posts/index.ts
@@ -10,9 +10,29 @@ export interface TeamInfo {
   grade: string;
 }
 
+export interface HiresResponseType {
+  ageGroup: string;
+  city: string;
+  date: string;
+  detail: string;
+  endTime: string;
+  groundName: string;
+  hirePlayerNumber: number;
+  position: string;
+  postId: number;
+  matchId?: number;
+  region: string;
+  startTime: string;
+  teamId: number;
+  teamLogo: string;
+  teamMannerTemperature: number;
+  teamName: string;
+}
+
 export interface PostWrapper {
   isMatch: boolean;
   selectedTeam: TeamInfo;
+  data: HiresResponseType[];
 }
 
 export interface Post {


### PR DESCRIPTION
## 추가한 기능
* 용병 리스트에서 api에서 받은 용병 신청글로 뷰에 출력
* 신청글 누르면 상세페이지 이동

## 체크리스트
- [x] 용병 리스트에서 api에서 받은 용병 신청글로 뷰에 출력
- [x] 신청글 누르면 상세페이지 이동

