### PR TITLE
feat: 용병 생성 페이지에서 사용자 입력에 따라 서버에 요청, 완료후 용병 리스트 페이지로 이동 (MAT-262)

### DIFF
--- a/src/components/selects/LocationSelect.tsx
+++ b/src/components/selects/LocationSelect.tsx
@@ -1,0 +1,90 @@
+/* eslint-disable react-hooks/exhaustive-deps */
+import React from 'react';
+import { Locations } from '@/types';
+import { Input } from '..';
+
+interface cityType {
+  cityId: number;
+  cityName: string;
+}
+
+interface groundType {
+  regionId: number;
+  groundId: number;
+  groundName: string;
+}
+
+interface regionType {
+  cityId: number;
+  regionId: number;
+  regionName: string;
+}
+
+interface locationInfoTypeWrapper {
+  locationInfo: Locations;
+  city: cityType;
+  region: regionType;
+  ground: groundType;
+  handleInput: (e: React.ChangeEvent, category: string) => void;
+}
+
+const LocationSelect = ({
+  locationInfo,
+  city,
+  region,
+  ground,
+  handleInput,
+}: locationInfoTypeWrapper) => {
+  const cityOptions = [
+    '행정구역',
+    ...locationInfo.cities.reduce((acc: string[], cityInfo) => {
+      if (cityInfo.cityName) acc.push(cityInfo.cityName || '');
+      return acc;
+    }, []),
+  ];
+  const regionOptions = [
+    '시/군/구',
+    ...locationInfo.regions.reduce((acc: string[], regionInfo) => {
+      if (regionInfo.cityId === city.cityId) acc.push(regionInfo.regionName || '');
+      return acc;
+    }, []),
+  ];
+  const groundOptions = [
+    '구장',
+    ...locationInfo.grounds.reduce((acc: string[], groundInfo) => {
+      if (groundInfo.regionId === region.regionId) acc.push(groundInfo.groundName || '');
+      return acc;
+    }, []),
+  ];
+
+  return (
+    <div>
+      <Input
+        inputId="inputCity"
+        type="dropbox"
+        options={cityOptions}
+        onChange={(e) => handleInput(e, 'city')}
+        styleProps={{ inputContentHeight: 'fit-content' }}
+        value={city.cityName}
+      />
+      <Input
+        inputId="inputRegion"
+        type="dropbox"
+        options={regionOptions}
+        onChange={(e) => handleInput(e, 'region')}
+        styleProps={{ inputContentHeight: 'fit-content' }}
+        value={region.regionName}
+      />
+      <Input
+        inputId="inputGround"
+        type="dropbox"
+        options={groundOptions}
+        onChange={(e) => handleInput(e, 'ground')}
+        styleProps={{ inputContentHeight: 'fit-content' }}
+        value={ground.groundName}
+      />
+    </div>
+  );
+};
+
+export default LocationSelect;

--- a/src/components/selects/LocationSelect.tsx
+++ b/src/components/selects/LocationSelect.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable react-hooks/exhaustive-deps */
 import React from 'react';
 import { Locations } from '@/types';
-import { Input } from '..';
+import { Input } from '@/components';
 
 interface cityType {
   cityId: number;

--- a/src/components/selects/LocationSelect.tsx
+++ b/src/components/selects/LocationSelect.tsx
@@ -26,6 +26,7 @@ interface locationInfoTypeWrapper {
   region: regionType;
   ground: groundType;
   handleInput: (e: React.ChangeEvent, category: string) => void;
+  firstLabelName: string;
 }
 
 const LocationSelect = ({
@@ -34,6 +35,7 @@ const LocationSelect = ({
   region,
   ground,
   handleInput,
+  firstLabelName,
 }: locationInfoTypeWrapper) => {
   const cityOptions = [
     '행정구역',
@@ -60,6 +62,7 @@ const LocationSelect = ({
   return (
     <div>
       <Input
+        labelName={firstLabelName}
         inputId="inputCity"
         type="dropbox"
         options={cityOptions}

--- a/src/components/selects/index.ts
+++ b/src/components/selects/index.ts
@@ -2,3 +2,4 @@ export { default as AgeGroup } from './AgeGroup';
 export { default as Date } from './Date';
 export { default as Place } from './Place';
 export { default as HiresPosition } from './HiresPosition';
+export { default as LocationSelect } from './LocationSelect';

--- a/src/pages/HiresCreate/HiresCreate.tsx
+++ b/src/pages/HiresCreate/HiresCreate.tsx
@@ -1,5 +1,7 @@
+/* eslint-disable react-hooks/exhaustive-deps */
 /* eslint-disable react/jsx-props-no-spreading */
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useCallback } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
 import LocalizationProvider from '@mui/lab/LocalizationProvider';
 import TextField from '@mui/material/TextField';
 import AdapterDateFns from '@mui/lab/AdapterDateFns';
@@ -7,15 +9,35 @@ import TimePicker from '@mui/lab/TimePicker';
 import DatePicker from '@mui/lab/DatePicker';
 import { useHistory } from 'react-router-dom';
 
-import { editHiresPosting, createHiresPosting } from '@/api/hires';
+import { editHiresPosting } from '@/api/hires';
+import { fetchLocation } from '@/api';
 
 import { InputDetail } from '@/components';
-import { Place, AgeGroup, HiresPosition } from '@/components/selects';
-import { previousHiresInfo } from '@/types';
+import { LocationSelect, AgeGroup, HiresPosition } from '@/components/selects';
+import { previousHiresInfo, Locations } from '@/types';
+import { RootState } from '@/store';
+import { match } from '@/store/match/match';
 
 const HIRED_NUMBER = [1, 2, 3, 4, 5, 6, 7, 8, 9];
 
 const DETAIL_PLACEHOLDER = '약속 잘지키고 유쾌하신분과 즐겁게 경기하고 싶습니다';
+
+const defaultCity = {
+  cityId: 0,
+  cityName: '',
+};
+
+const defaultRegion = {
+  cityId: 0,
+  regionId: 0,
+  regionName: '',
+};
+
+const defaultGround = {
+  regionId: 0,
+  groundId: 0,
+  groundName: '',
+};
 
 const HiresCreate = ({
   // Todo(홍중) : 디폴트값을 매칭에서도 사용가능하도록 추후 consts로 분리
@@ -45,12 +67,51 @@ const HiresCreate = ({
   const [hirePlayerNumber, sethirePlayerNumber] = useState<number>(prevHiredNumber);
   const [position, setPosition] = useState<string>(prevPosition);
   const [ageGroup, setAgeGroup] = useState<string>(prevAgeGroup);
-  const [city, setCity] = useState<string>(prevCity);
-  const [region, setRegion] = useState<string>(prevRegion);
-  const [groundName, setGroundName] = useState<string>(prevGroundName);
   const [detail, setDetail] = useState<string>(prevDetail || DETAIL_PLACEHOLDER);
+  const [city, setCity] = useState(defaultCity);
+  const [region, setRegion] = useState(defaultRegion);
+  const [ground, setGround] = useState(defaultGround);
 
   const history = useHistory();
+
+  const dispatch = useDispatch();
+  const { locations } = useSelector((store: RootState) => store.match.data);
+  const [locationInfo, setLocationInfo] = useState<Locations>(locations);
+
+  const getLocations = useCallback(async () => {
+    const locationData = await fetchLocation();
+    setLocationInfo(locationData);
+    dispatch(match.actions.setLocations({ locations: locationData }));
+  }, []);
+
+  useEffect(() => {
+    if (locationInfo.cities.length < 1) {
+      getLocations();
+    } else {
+      console.log(locationInfo);
+      const cityOptions = [
+        '행정구역',
+        ...locationInfo.cities.reduce((acc: string[], cityInfo) => {
+          if (cityInfo.cityName) acc.push(cityInfo.cityName || '');
+          return acc;
+        }, []),
+      ];
+      const regionOptions = [
+        '시/군/구',
+        ...locationInfo.regions.reduce((acc: string[], regionInfo) => {
+          if (regionInfo.cityId === city.cityId) acc.push(regionInfo.regionName || '');
+          return acc;
+        }, []),
+      ];
+      const groundOptions = [
+        '구장',
+        ...locationInfo.grounds.reduce((acc: string[], groundInfo) => {
+          if (groundInfo.regionId === region.regionId) acc.push(groundInfo.groundName || '');
+          return acc;
+        }, []),
+      ];
+    }
+  }, [locations]);
 
   useEffect(() => {
     const newDate = new Date();
@@ -77,6 +138,45 @@ const HiresCreate = ({
     currentDate.setMonth(newDate.getMonth());
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [currentMonth]);
+
+  const handleInput = (e: React.ChangeEvent, category: string) => {
+    const targetInput: string = (e.target as HTMLInputElement).value;
+
+    if (category === 'city') {
+      const selectedCity = locationInfo.cities.filter(
+        (cityInfo) => cityInfo.cityName === targetInput
+      )[0];
+      setCity({
+        cityId: selectedCity?.cityId || 0,
+        cityName: selectedCity?.cityName || '',
+      });
+      setRegion(defaultRegion);
+      setGround(defaultGround);
+      return;
+    }
+    if (category === 'region') {
+      const selectedRegion = locationInfo.regions.filter(
+        (regionInfo) => regionInfo.regionName === targetInput
+      )[0];
+      setRegion({
+        cityId: selectedRegion?.cityId || 0,
+        regionId: selectedRegion?.regionId || 0,
+        regionName: selectedRegion?.regionName || '',
+      });
+      setGround(defaultGround);
+      return;
+    }
+    if (category === 'ground') {
+      const selectedGround = locationInfo.grounds.filter(
+        (groundInfo) => groundInfo.groundName === targetInput
+      )[0];
+      setGround({
+        regionId: selectedGround?.regionId || 0,
+        groundId: selectedGround?.groundId || 0,
+        groundName: selectedGround?.groundName || '',
+      });
+    }
+  };
 
   const hanldeChangeDate = (selectedDate: React.SetStateAction<Date | null>) => {
     const newDate = selectedDate ? new Date(selectedDate.toString()) : new Date();
@@ -127,24 +227,6 @@ const HiresCreate = ({
     setAgeGroup(`${ageNumber}대`);
   };
 
-  const handleChangeCity = (event: React.ChangeEvent<HTMLSelectElement>) => {
-    const { value } = event.target;
-
-    setCity(value);
-  };
-
-  const handleChangeRegion = (event: React.ChangeEvent<HTMLSelectElement>) => {
-    const { value } = event.target;
-
-    setRegion(value);
-  };
-
-  const handleChangeGroundName = (event: React.ChangeEvent<HTMLSelectElement>) => {
-    const { value } = event.target;
-
-    setGroundName(value);
-  };
-
   // Todo(홍중) : api 통신 추후 추가 (2021-12-17)
   // const handleClickCreatePosting = async () => {
   //   const data = {
@@ -166,16 +248,17 @@ const HiresCreate = ({
 
   const handleClickSelectDone = () => {
     const data = {
-      city,
-      region,
-      groundName,
+      ageGroup,
+      cityId: city.cityId,
       date: formattedDate || prevDate,
-      startTime: formatedStartTime,
+      detail,
       endTime: formatedEndTime,
+      groundId: ground.groundId,
       hirePlayerNumber,
       position,
-      ageGroup,
-      detail,
+      regionId: region.regionId,
+      startTime: formatedStartTime,
+      teamId: 0,
     };
 
     const startHour = startTime?.getHours();
@@ -197,12 +280,6 @@ const HiresCreate = ({
     // Todo(홍중) : am일때 올바름에도 다시 입력 요구하는것 수정하기(2021-12-19)
     if (isStartHourBigger || (!isStartHourBigger && isStartMinuteBigger)) {
       alert('시간을 다시 입력해주세요');
-      return;
-    }
-
-    if (city === '행정구역' || region === '시/군/구' || groundName === '구장') {
-      alert('장소를 입력해주세요');
-      return;
     }
 
     // Todo(홍중) : 입력된 데이터 서버에 보내기
@@ -286,10 +363,12 @@ const HiresCreate = ({
           renderInput={(params) => <TextField {...params} />}
         />
       </LocalizationProvider>
-      <Place
-        handleChangeCity={handleChangeCity}
-        handleChangeRegion={handleChangeRegion}
-        handleChangeGroundName={handleChangeGroundName}
+      <LocationSelect
+        locationInfo={locationInfo}
+        city={city}
+        region={region}
+        ground={ground}
+        handleInput={handleInput}
       />
       <InputDetail labelName="상세정보" placeholder={detail} onChange={handleChangeDetail} />
       {prevCity === '행정구역' ? (

--- a/src/pages/HiresCreate/HiresCreate.tsx
+++ b/src/pages/HiresCreate/HiresCreate.tsx
@@ -9,7 +9,7 @@ import TimePicker from '@mui/lab/TimePicker';
 import DatePicker from '@mui/lab/DatePicker';
 import { useHistory } from 'react-router-dom';
 
-import { editHiresPosting, createHiresPosting } from '@/api/hires';
+import { editHiresPosting, createHiresPosting, hiresPosting } from '@/api/hires';
 import { fetchAuthorizedTeams, fetchLocation } from '@/api';
 
 import { InputDetail, Input } from '@/components';
@@ -227,23 +227,10 @@ const HiresCreate = ({
   };
 
   // Todo(홍중) : api 통신 추후 추가 (2021-12-17)
-  // const handleClickCreatePosting = async () => {
-  //   const data = {
-  //     ageGroup: '20대',
-  //     cityId: 1,
-  //     date: '2021-12-15',
-  //     detail: '상세내용입니다~',
-  //     endTime: '19:30:00',
-  //     groundId: 1,
-  //     hirePlayerNumber: 3,
-  //     position: '윙백',
-  //     regionId: 1,
-  //     startTime: '17:30:00',
-  //     teamId: 1,
-  //   };
-
-  //   const res = await createHiresPosting(data);
-  // };
+  const handleClickCreatePosting = async (data: hiresPosting) => {
+    await createHiresPosting(data);
+    history.push(`/hires`);
+  };
 
   const handleClickSelectDone = () => {
     const data = {
@@ -282,8 +269,8 @@ const HiresCreate = ({
     }
 
     // Todo(홍중) : 입력된 데이터 서버에 보내기
-    // handleClickCreatePosting(data);
-    console.log(data);
+    handleClickCreatePosting(data);
+    // console.log(data);
   };
 
   const handleChangePosition = (event: React.ChangeEvent) => {


### PR DESCRIPTION
## 추가한 기능
용병 생성 페이지에서 사용자 입력에 따라 서버에 요청, 완료후 용병 리스트 페이지로 이동

## 체크리스트
- [x] 장소 입력 컴포넌트화
- [x] 장소 정보를 더미데이터에서 서버에서 받은 장소로 변경
- [x] 팀선택 추가
- [x] 생성 버튼 눌러서 용병글 생성, 용병 리스트 페이지 이동, 용병리스트에서 생성된 용병글 확인 가능

## 주의사항
LocationSelect는 용스톤 코드 활용하여 컴포넌트화 한것이어서 리뷰는 안해주셔도 될것 같습니다!