### PR TITLE
refactor: 매칭 생성,수정 시간 관련 이슈 해결

### DIFF
--- a/src/components/common/AttitudeTag/attitudeTag.module.scss
+++ b/src/components/common/AttitudeTag/attitudeTag.module.scss
@@ -12,6 +12,7 @@
   font-size: 0.5rem;
   white-space: nowrap;
   text-align: center;
+  text-indent: 0;
   text-overflow: ellipsis;
   background-color: color.$primary;
   border-radius: 1rem;

--- a/src/components/common/TabBar/TabBar.tsx
+++ b/src/components/common/TabBar/TabBar.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import classNames from 'classnames';
 import styles from './TabBar.module.scss';
@@ -9,6 +9,11 @@ const TabBar = () => {
   const navList = ['matches', 'hires', 'team', 'user'];
   const thisPage = window.location.pathname.split('/')[1];
   const [nowPage, setNowPage] = useState(navList.includes(thisPage) ? thisPage : 'home');
+
+  useEffect(() => {
+    const newThisPage = window.location.pathname.split('/')[1];
+    setNowPage(navList.includes(thisPage) ? newThisPage : 'home');
+  }, []);
 
   return (
     <div className={classNames(tabBar)}>

--- a/src/pages/EditMatch/EditMatchPage.tsx
+++ b/src/pages/EditMatch/EditMatchPage.tsx
@@ -47,6 +47,13 @@ const defaultGround = {
   groundName: '',
 };
 
+const toTimeString = (date: Date) =>
+  date.toLocaleTimeString('fr-BE', {
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+  });
+
 const EditMatch = () => {
   const dispatch = useDispatch();
   const history = useHistory();
@@ -300,7 +307,7 @@ const EditMatch = () => {
       setIsModal3Open(true);
       return;
     }
-    if (startTime > endTime) {
+    if (toTimeString(startTime) > toTimeString(endTime)) {
       setErrorMessage('시작시간이 종료시간보다 빠를 수 없습니다');
       setIsModal3Open(true);
       return;

--- a/src/pages/NewMatch/NewMatchPage.tsx
+++ b/src/pages/NewMatch/NewMatchPage.tsx
@@ -51,6 +51,13 @@ const defaultGround = {
   groundName: '',
 };
 
+const toTimeString = (date: Date) =>
+  date.toLocaleTimeString('fr-BE', {
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+  });
+
 const NewMatch = () => {
   const dispatch = useDispatch();
   const [newMatchId, setNewMatchId] = useState(0);
@@ -335,17 +342,16 @@ const NewMatch = () => {
       setIsModal3Open(true);
       return;
     }
-    if (startDate > endDate) {
-      setErrorMessage('종료일자가 시작일자보다 빠를 수 없습니다');
-      setIsModal3Open(true);
-      return;
-    }
-    if (startTime > endTime) {
+    if (toTimeString(startTime) > toTimeString(endTime)) {
       setErrorMessage('시작시간이 종료시간보다 빠를 수 없습니다');
       setIsModal3Open(true);
       return;
     }
-
+    if (startDate.getDate() > endDate.getDate()) {
+      setErrorMessage('종료일자가 시작일자보다 빠를 수 없습니다');
+      setIsModal3Open(true);
+      return;
+    }
     if (Number.isNaN(cost)) {
       setErrorMessage('참가비는 숫자만 입력할 수 있습니다');
       setIsModal3Open(true);


### PR DESCRIPTION
시작시간 PM, 종료시간 AM 일 경우 백엔드 밸리데이션에서 막히던것 수정

프론트에서 상정한 로직에서는 시간을 구할때도 날짜가 상정되어, 
시작시간이 PM일 때, 
종료시간이 AM이 될 경우,
하루가 지난것으로 간주했음. (날짜가 지나므로 문제가 발생하지 않는다고 상정)

하지만 백엔드는 날짜와 시간을 완전 별개로 취급.
날짜가 지나는 것은 고려하지 않고 시간만 확인하는 로직이기에 백엔드 밸리데이션에 걸림
프론트에서도 시간에선 날짜를 고려하지 않는 방향으로 수정.
